### PR TITLE
move white/blacklist form above the table

### DIFF
--- a/data/web/user.php
+++ b/data/web/user.php
@@ -502,16 +502,6 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
 			<div class="col-sm-6">
 				<h4><?=$lang['user']['spamfilter_wl'];?></h4>
         <p><?=$lang['user']['spamfilter_wl_desc'];?></p>
-        <div class="table-responsive">
-          <table class="table table-striped table-condensed" id="wl_policy_mailbox_table"></table>
-        </div>
-
-        <div class="mass-actions-user">
-          <div class="btn-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
-            <a class="btn btn-sm btn-default" id="toggle_multi_select_all" data-id="policy_wl_mailbox" href="#"><span class="glyphicon glyphicon-check" aria-hidden="true"></span> <?=$lang['mailbox']['toggle_all'];?></a>
-            <a class="btn btn-sm btn-danger" data-action="delete_selected" data-id="policy_wl_mailbox" data-api-url='delete/mailbox-policy' href="#"><?=$lang['mailbox']['remove'];?></a></li>
-          </div>
-        </div>
         <form class="form-inline" data-id="add_wl_policy_mailbox">
           <div class="input-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
             <input type="text" class="form-control" name="object_from" placeholder="*@example.org" required>
@@ -520,20 +510,19 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
             </span>
           </div>
         </form>
+        <div class="mass-actions-user">
+          <div class="btn-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
+            <a class="btn btn-sm btn-default" id="toggle_multi_select_all" data-id="policy_wl_mailbox" href="#"><span class="glyphicon glyphicon-check" aria-hidden="true"></span> <?=$lang['mailbox']['toggle_all'];?></a>
+            <a class="btn btn-sm btn-danger" data-action="delete_selected" data-id="policy_wl_mailbox" data-api-url='delete/mailbox-policy' href="#"><?=$lang['mailbox']['remove'];?></a></li>
+          </div>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-striped table-condensed" id="wl_policy_mailbox_table"></table>
+        </div>
       </div>
 			<div class="col-sm-6">
 				<h4><?=$lang['user']['spamfilter_bl'];?></h4>
         <p><?=$lang['user']['spamfilter_bl_desc'];?></p>
-        <div class="table-responsive">
-          <table class="table table-striped table-condensed" id="bl_policy_mailbox_table"></table>
-        </div>
-
-        <div class="mass-actions-user">
-          <div class="btn-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
-            <a class="btn btn-sm btn-default" id="toggle_multi_select_all" data-id="policy_bl_mailbox" href="#"><span class="glyphicon glyphicon-check" aria-hidden="true"></span> <?=$lang['mailbox']['toggle_all'];?></a>
-            <a class="btn btn-sm btn-danger" data-action="delete_selected" data-id="policy_bl_mailbox" data-api-url='delete/mailbox-policy' href="#"><?=$lang['mailbox']['remove'];?></a></li>
-          </div>
-        </div>
         <form class="form-inline" data-id="add_bl_policy_mailbox">
           <div class="input-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
             <input type="text" class="form-control" name="object_from" placeholder="*@example.org" required>
@@ -542,7 +531,15 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
             </span>
           </div>
         </form>
-
+        <div class="mass-actions-user">
+          <div class="btn-group" data-acl="<?=$_SESSION['acl']['spam_policy'];?>">
+            <a class="btn btn-sm btn-default" id="toggle_multi_select_all" data-id="policy_bl_mailbox" href="#"><span class="glyphicon glyphicon-check" aria-hidden="true"></span> <?=$lang['mailbox']['toggle_all'];?></a>
+            <a class="btn btn-sm btn-danger" data-action="delete_selected" data-id="policy_bl_mailbox" data-api-url='delete/mailbox-policy' href="#"><?=$lang['mailbox']['remove'];?></a></li>
+          </div>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-striped table-condensed" id="bl_policy_mailbox_table"></table>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I would like to propose a UI change for the whitelist and blacklist forms. I had to add many entries to the blacklist and it is a little unfortunate that the form field is below the table. I always need to scroll back down to add the next one.
As it is very easy from my point of view to make the usability better in this aspect here is my PR.

It is simply moving the forms above the table.

![mailcow-blacklist-form-reorder](https://user-images.githubusercontent.com/2772132/107631496-5ea06a00-6c65-11eb-9b13-aa762e5f55be.png)

